### PR TITLE
Add optional config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ cd vlight_v044
 python3 -m venv venv
 source venv/bin/activate
 pip install .
-vlight
-rm -rf ~/.vlight/state #如果异常退出，导致空或非法的 JSON，从而在 json.load() 时出错
+vlight            # 默认读取当前目录下的 configuration.yaml
+vlight -c /path/to/config.yaml  # 如需指定其他配置文件
+rm -rf ~/.vlight/state #如果异常退出，导致空或非法的 JSON,从而在 json.load() 时出错
 ```
 
 ---

--- a/vlight/main.py
+++ b/vlight/main.py
@@ -1,10 +1,20 @@
 import time
+import argparse
 from vlight.config import load_config
 from vlight.logger import init_logger
 from vlight.mqtt_client import MQTTManager
 
 def main():
-    config = load_config()
+    parser = argparse.ArgumentParser(description="Start vlight service")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="configuration.yaml",
+        help="Path to configuration YAML file",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
     logger = init_logger(config)
     mqtt_manager = MQTTManager(config, logger)
     mqtt_manager.start()


### PR DESCRIPTION
## Summary
- add CLI option `--config` to choose configuration file
- document optional config argument in README

## Testing
- `python -m vlight.main --help` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml paho-mqtt` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_684d46d1b380832587337f26752c3839