### PR TITLE
Fix identifiers in discovery payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ homeassistant/light/<pid>/<did>/config
   "schema": "json",
   "device": {
     "identifiers": ["light-001"],
-    "name": "vLight 虚拟灯 light-001",
+    "name": "vLight 虚拟灯控制器",
     "manufacturer": "LinknLink",
     "model": "vlight-sim",
     "sw_version": "0.4.4"

--- a/vlight/light_device.py
+++ b/vlight/light_device.py
@@ -67,7 +67,7 @@ class LightDevice:
             "color_temp_command_topic": self.base_topic + "/colortemp",
             "schema": "json",
             "device": {
-                "identifiers": ["vlight-hub"],
+                "identifiers": [self.did],
                 "name": "vLight 虚拟灯控制器",
                 "manufacturer": "LinknLink",
                 "model": "vlight-sim",


### PR DESCRIPTION
## Summary
- use each light's id in discovery payload identifiers
- update README example to match

## Testing
- `python -m py_compile vlight/light_device.py`
- `python -m vlight.main --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684d46e862dc832588a71d57176a08ff