### PR TITLE
Implement static_count for Vlight devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * ✅ 每个灯设备对应 Home Assistant 中一个独立设备页（通过唯一 `device.identifiers` 实现）
 * 支持 pip install 安装，使用 CLI 命令 `vlight` 启动
 * ✅ 新增 `vlight.__version__` 可查看当前库版本
+* ✅ 新增 `static_count` 可设置不自动变化的设备数量
 
 ---
 
@@ -174,6 +175,7 @@ lights:
   prefix: "light"
   pid: "vlight"
   simulate_behavior: true
+  static_count: 0
   default_state:
     state: "OFF"
     brightness: 128

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -10,6 +10,7 @@ mqtt:
 lights:
   count: 1000
   simulate_behavior: true
+  static_count: 0
   pid: "vlight"
   prefix: "light"
   default_state:

--- a/vlight/mqtt_client.py
+++ b/vlight/mqtt_client.py
@@ -35,9 +35,11 @@ class MQTTManager:
         base_topic = mqtt_cfg['base_topic']
         discovery_prefix = mqtt_cfg['discovery_prefix']
         simulate = self.config['lights'].get('simulate_behavior', False)
+        static_count = self.config['lights'].get('static_count', 0)
 
-        for defn in self.config['lights']['definitions']:
+        for idx, defn in enumerate(self.config['lights']['definitions']):
             state = dict(self.config['lights']['default_state'])
+            device_simulate = simulate and idx >= static_count
             device = LightDevice(
                 did=defn['did'],
                 pid=defn['pid'],
@@ -46,7 +48,7 @@ class MQTTManager:
                 base_topic=base_topic,
                 logger=self.logger,
                 initial_state=state,
-                simulate=simulate
+                simulate=device_simulate
             )
             self.devices.append(device)
 


### PR DESCRIPTION
## Summary
- add `static_count` option for lights
- mention new config option in README
- configure per-device simulation based on `static_count`

## Testing
- `python -m py_compile vlight/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684d4c99f7348325bef52a71eb790a44