### PR TITLE
Add connection failure handling in MQTTManager

### DIFF
--- a/vlight/mqtt_client.py
+++ b/vlight/mqtt_client.py
@@ -15,6 +15,14 @@ class MQTTManager:
         self.sensors = []
 
     def on_connect(self, client, userdata, flags, rc):
+        """Handle connection callbacks from the MQTT client."""
+        if rc != 0:
+            # Non-zero return codes indicate connection failure. Log the issue
+            # and raise an exception so that the service can react accordingly
+            # instead of silently continuing in a bad state.
+            self.logger.error(f"Failed to connect to MQTT broker, rc={rc}")
+            raise ConnectionError(f"MQTT connection failed with code {rc}")
+
         self.logger.info("Connected to MQTT broker with code " + str(rc))
         for dev in self.devices:
             dev.announce_discovery()


### PR DESCRIPTION
## Summary
- log a connection error when MQTT connection fails
- raise an exception so service startup fails

## Testing
- `python -m py_compile vlight/mqtt_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d70593d6483259954bfe9a96838fe