### PR TITLE
Remove device_type from sensor discovery

### DIFF
--- a/vlight/temp_sensor.py
+++ b/vlight/temp_sensor.py
@@ -26,7 +26,6 @@ class TempSensor:
             "unique_id": self.did,
             "name": self.did,
             "availability_topic": self.availability_topic,
-            "device_type": "sensor",
             "device_class": "temperature",
             "state_topic": self.state_topic,
             "value_template": "{{ (value_json.envtemp * 0.1) | round(1) }}",


### PR DESCRIPTION
## Summary
- drop deprecated `device_type` from temp sensor discovery payload

## Testing
- `python -m compileall -q vlight`

------
https://chatgpt.com/codex/tasks/task_e_684d705135a88325a5ac5ead70c6aa09